### PR TITLE
fix: remove eleventy pathprefix option from document by using custom domain

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -39,10 +39,6 @@ npm install
 ```bash
 npx @11ty/eleventy --serve
 ```
-### GitHub Pages 相当のビルド確認
-```bash
-npx @11ty/eleventy --pathprefix=challenge-club-homepage
-```
 
 ---
 

--- a/Readme.md
+++ b/Readme.md
@@ -44,9 +44,6 @@ $ cd challenge-club-homepage
 ```bash
 # 開発用（/posts/ などのリンクが / から始まる場合はこちら）
 $ npx @11ty/eleventy --serve
-
-# 本番と同じパス（GitHub Pages の /challenge-club-homepage/ を再現）
-$ npx @11ty/eleventy --pathprefix=challenge-club-homepage
 ```
 
 ## 編集・投稿方法（コントリビューション）


### PR DESCRIPTION
Close #47 