### PR TITLE
ci: update GitHub Actions runtimes

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -14,6 +14,12 @@ on:
   schedule:
     - cron: '0 15 * * 0' # 毎週日曜 24:00 JST（= 15:00 UTC）
   workflow_dispatch:
+    inputs:
+      dry_run:
+        description: 'Skip committing docs and pushing to main'
+        type: boolean
+        required: false
+        default: true
 
 jobs:
   build:
@@ -23,18 +29,18 @@ jobs:
     steps:
       - name: Create GitHub App token
         id: app-token
-        uses: actions/create-github-app-token@v1
+        uses: actions/create-github-app-token@v3.0.0
         with:
           app-id: ${{ secrets.APP_ID }}
           private-key: ${{ secrets.PRIVATE_KEY }}
 
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v5
         with:
           token: ${{ steps.app-token.outputs.token }}
 
       - name: Setup Node.js
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v5
         with:
           node-version: '18'
           cache: 'npm'
@@ -59,7 +65,7 @@ jobs:
           npx cross-env ELEVENTY_ENV=production npm run build
 
       - name: Commit and push to docs
-        if: github.event_name == 'push' || github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
+        if: github.event_name == 'push' || github.event_name == 'schedule' || (github.event_name == 'workflow_dispatch' && !inputs.dry_run)
         env:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
         run: |

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -29,7 +29,7 @@ jobs:
     steps:
       - name: Create GitHub App token
         id: app-token
-        uses: actions/create-github-app-token@v3.0.0
+        uses: actions/create-github-app-token@v3
         with:
           app-id: ${{ secrets.APP_ID }}
           private-key: ${{ secrets.PRIVATE_KEY }}

--- a/.github/workflows/pages-deploy.yml
+++ b/.github/workflows/pages-deploy.yml
@@ -25,13 +25,13 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Setup Pages
         uses: actions/configure-pages@v5
 
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@v3
+        uses: actions/upload-pages-artifact@v4
         with:
           path: './docs'  # deploy.yml でコミットされたビルド成果物
 


### PR DESCRIPTION
## What changed
- updated `actions/create-github-app-token` from `v1` to `v3`
- updated `actions/checkout` from `v3`/`v4` to `v5`
- updated `actions/setup-node` from `v3` to `v5`
- updated `actions/upload-pages-artifact` from `v3` to `v4`
- added a `workflow_dispatch` `dry_run` input so manual runs can validate the workflow without committing `docs/` or pushing to `main`

## Why
GitHub Actions was warning that Node.js 20-based actions are deprecated. This updates the affected actions to current majors, including `create-github-app-token@v3`, which uses the current Node 24-based runtime while still allowing patch/minor updates within the major version.

## Impact
- normal homepage update flows on `push` to `main` and `schedule` remain unchanged
- manual `workflow_dispatch` runs default to a safe dry-run mode
- pull request runs continue to avoid committing generated `docs/`

## Validation
- manually ran `Build and Commit to docs` on branch `codex/actions-node24-warning-fix` with `dry_run=true`
- confirmed the run used `actions/create-github-app-token@v3`, `actions/checkout@v5`, and `actions/setup-node@v5`
- confirmed the previous `Node.js 20 actions are deprecated` warning no longer appeared in the run summary